### PR TITLE
Update chain observations

### DIFF
--- a/pages/nodes/index.vue
+++ b/pages/nodes/index.vue
@@ -185,8 +185,10 @@
             </span>
             <span v-else-if="props.column.field.includes('chains.')">
               <span v-if="props.formattedRow[props.column.field] == 0" style="color: #81C784;">OK</span>
-              <span v-else-if="props.formattedRow[props.column.field] < 10000" style="color: #EF5350;">-{{ props.formattedRow[props.column.field] }}</span>
-              <DangerIcon v-else v-tooltip="`-${props.formattedRow[props.column.field]}`" class="table-icon" style="fill: #EF5350;" />
+              <span v-else-if="0 < props.formattedRow[props.column.field] && props.formattedRow[props.column.field] < 10000" style="color: #FFC107;">{{ props.formattedRow[props.column.field] }}</span>
+              <span v-else-if="0 > props.formattedRow[props.column.field] && props.formattedRow[props.column.field] > -10000" style="color: #EF5350;">{{ props.formattedRow[props.column.field] }}</span>
+              <DangerIcon v-else-if="props.formattedRow[props.column.field] > 10000" v-tooltip="`${props.formattedRow[props.column.field]}`" class="table-icon" style="fill: #FFC107;" />
+              <DangerIcon v-else v-tooltip="`${props.formattedRow[props.column.field]}`" class="table-icon" style="fill: #EF5350;" />
             </span>
             <span v-else>
               {{ props.formattedRow[props.column.field] }}

--- a/pages/thorfi/savers.vue
+++ b/pages/thorfi/savers.vue
@@ -218,8 +218,8 @@ export default {
         {
           name: 'APR Mean',
           value: this.$options.filters.percent(saversStat.meanAPR / this.tables.saversRows.data.length, 2),
-          change: this.$options.filters.percent((saversStat.meanAPR - oldSaversStat.meanAPR) / this.tables.saversRows.data.length, 4),
-          isDown: +saversStat.meanAPR < +oldSaversStat.meanAPR
+          // change: this.$options.filters.percent((saversStat.meanAPR - oldSaversStat.meanAPR) / this.tables.saversRows.data.length, 4),
+          // isDown: +saversStat.meanAPR < +oldSaversStat.meanAPR
         }
       ]
     },
@@ -229,7 +229,7 @@ export default {
   },
   mounted () {
     this.saverCols[5].hidden = this.networkEnv === 'stagenet'
-    this.$api.getPools().then(async ({ data }) => {
+    this.$api.getPools('7d').then(async ({ data }) => {
       const runePrice = (await this.$api.getStats()).data.runePriceUSD
       const saversExtraData = (await this.$api.getSaversExtraData()).data
       const saversOldData = (await this.$api.getOldSaversExtraData()).data
@@ -250,7 +250,7 @@ export default {
         depthToUnitsRatio: this.$options.filters.number(+p.saversDepth / +p.saversUnits, '0.00000'),
         filled: saversExtraData[p.asset]?.filled,
         saversCount: saversExtraData[p.asset]?.saversCount,
-        saverReturn: saversExtraData[p.asset]?.saverReturn,
+        saverReturn: +p.saversAPR,
         synthSupply: saversExtraData[p.asset]?.synthSupply,
         earned: saversExtraData[p.asset]?.earned,
         changes: changes[p.asset]
@@ -342,11 +342,11 @@ export default {
             isDown: (newData[asset].saversCount < (oldData[asset].saversCount ?? 0)),
             enable: (newData[asset].saversCount ?? 0) - (oldData[asset].saversCount ?? 0)
           },
-          saverReturn: {
-            value: this.percentageFormat(newData[asset].saverReturn - (oldData[asset].saverReturn ?? 0), 2),
-            isDown: (newData[asset].saverReturn < (oldData[asset].saverReturn ?? 0)),
-            enable: (newData[asset].saverReturn ?? 0) - (oldData[asset].saverReturn ?? 0)
-          },
+          // saverReturn: {
+          //   value: this.percentageFormat(newData[asset].saverReturn - (oldData[asset].saverReturn ?? 0), 2),
+          //   isDown: (newData[asset].saverReturn < (oldData[asset].saverReturn ?? 0)),
+          //   enable: (newData[asset].saverReturn ?? 0) - (oldData[asset].saverReturn ?? 0)
+          // },
           earned: {
             value: this.baseAmountFormat(oldData[asset].deltaEarned ?? 0),
             isDown: oldData[asset].deltaEarned > 0,


### PR DESCRIPTION
### Problem
The current height for chain observations used the `max` that any active node observed. However, recently some nodes had invalid heights because they were higher than the current tip of the specific chain.

### Solution
Use the height that the most active node observed. If a node is ahead in terms of observation, it is indicated by a positive number and yellow color.

<img width="2608" alt="image" src="https://github.com/thorchain/thorchain-explorer-v2/assets/116079937/1cc3d7f9-4ca4-4277-91ca-ce663425cbf4">