### PR TITLE
Update chain observations

### DIFF
--- a/pages/nodes/index.vue
+++ b/pages/nodes/index.vue
@@ -185,8 +185,10 @@
             </span>
             <span v-else-if="props.column.field.includes('chains.')">
               <span v-if="props.formattedRow[props.column.field] == 0" style="color: #81C784;">OK</span>
-              <span v-else-if="props.formattedRow[props.column.field] < 10000" style="color: #EF5350;">-{{ props.formattedRow[props.column.field] }}</span>
-              <DangerIcon v-else v-tooltip="`-${props.formattedRow[props.column.field]}`" class="table-icon" style="fill: #EF5350;" />
+              <span v-else-if="0 < props.formattedRow[props.column.field] && props.formattedRow[props.column.field] < 10000" style="color: #FFC107;">{{ props.formattedRow[props.column.field] }}</span>
+              <span v-else-if="0 > props.formattedRow[props.column.field] && props.formattedRow[props.column.field] > -10000" style="color: #EF5350;">{{ props.formattedRow[props.column.field] }}</span>
+              <DangerIcon v-else-if="props.formattedRow[props.column.field] > 10000" v-tooltip="`${props.formattedRow[props.column.field]}`" class="table-icon" style="fill: #FFC107;" />
+              <DangerIcon v-else v-tooltip="`${props.formattedRow[props.column.field]}`" class="table-icon" style="fill: #EF5350;" />
             </span>
             <span v-else>
               {{ props.formattedRow[props.column.field] }}


### PR DESCRIPTION
### Problem
The current height for chain observations used the `max` that any active node observed. However, recently some nodes had invalid heights because they were higher than the current tip of the specific chain.

### Solution
Use the height that the most active node observed. If a node is ahead in terms of observation, it is indicated by a positive number and yellow color.

<img width="2608" alt="image" src="https://github.com/thorchain/thorchain-explorer-v2/assets/116079937/1cc3d7f9-4ca4-4277-91ca-ce663425cbf4">