### PR TITLE
Fix meta viewport syntax

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -9,7 +9,7 @@ export default {
     },
     meta: [
       { charset: 'utf-8' },
-      { name: 'viewport', content: 'width=device-width, height=device-height,  initial-scale=1.0, user-scalable=no;user-scalable=0;' },
+      { name: 'viewport', content: 'width=device-width, height=device-height, initial-scale=1.0, user-scalable=no' },
       { hid: 'description', name: 'description', content: '' },
       { name: 'format-detection', content: 'telephone=no' }
     ],


### PR DESCRIPTION
- Content is comma-delimited; semi-colon is not permitted.  Use of it (including at end-of-line) will cause browsers to throw a warning in the console.  Ex. Chrome: "apr:4 Error parsing a meta element's content: ';' is not a valid key-value pair separator. Please use ',' instead."

- The user-scalable property, per WCAG 2.1, only permits the word "no" to indicate zoom capability should be disabled.  "0" isn't permitted, despite the fact that "yes" OR "1" can be used to enable it.  (In short: WCAG really wants yes/no used for booleans, not integers, but they're permissive with "1" but not "0".  Weird but true.)

Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag